### PR TITLE
Do not include bonded/notbonded tokens in circulating supply

### DIFF
--- a/src/service/treasury/circulatingSupply.ts
+++ b/src/service/treasury/circulatingSupply.ts
@@ -42,13 +42,13 @@ export async function getCirculatingSupply(input: string): Promise<string> {
     circulatingSupply = minus(circulatingSupply, unvested[0].amount)
   }
 
+  // Remove supply in community pool
+  if (communityPool) {
+    circulatingSupply = minus(circulatingSupply, communityPool.find((c) => c.denom === denom)?.amount || '0')
+  }
+
   // Special conditions for Luna
   if (denom === BOND_DENOM) {
-    // Remove Luna in community pool
-    if (communityPool) {
-      circulatingSupply = minus(circulatingSupply, communityPool.find((c) => c.denom === denom)?.amount || '0')
-    }
-
     if (stakingPool) {
       circulatingSupply = minus(circulatingSupply, stakingPool.bonded_tokens || '0')
       // not_bonded_tokens is token that is currently unbonding or staked with inactive validators

--- a/src/service/treasury/circulatingSupply.ts
+++ b/src/service/treasury/circulatingSupply.ts
@@ -51,7 +51,9 @@ export async function getCirculatingSupply(input: string): Promise<string> {
 
     if (stakingPool) {
       circulatingSupply = minus(circulatingSupply, stakingPool.bonded_tokens || '0')
-      circulatingSupply = minus(circulatingSupply, stakingPool.not_bonded_tokens || '0')
+      // not_bonded_tokens is token that is currently unbonding or staked with inactive validators
+      // it has not been removed from the total supply in the past, so we should keep it that way
+      // circulatingSupply = minus(circulatingSupply, stakingPool.not_bonded_tokens || '0')
     }
 
     // Remove Luna in bank wallets

--- a/src/service/treasury/circulatingSupply.ts
+++ b/src/service/treasury/circulatingSupply.ts
@@ -19,7 +19,11 @@ export async function getCirculatingSupply(input: string): Promise<string> {
   }
 
   const denom = isActiveCurrency(input) ? currencyToDenom(input.toLowerCase()) : input
-  const [totalSupply, communityPool] = await Promise.all([getTotalSupply(denom), lcd.getCommunityPool()])
+  const [totalSupply, communityPool, stakingPool] = await Promise.all([
+    getTotalSupply(denom),
+    lcd.getCommunityPool(),
+    lcd.getStakingPool()
+  ])
   const unvested = await getRepository(UnvestedEntity).find({
     where: {
       denom
@@ -43,6 +47,11 @@ export async function getCirculatingSupply(input: string): Promise<string> {
     // Remove Luna in community pool
     if (communityPool) {
       circulatingSupply = minus(circulatingSupply, communityPool.find((c) => c.denom === denom)?.amount || '0')
+    }
+
+    if (stakingPool) {
+      circulatingSupply = minus(circulatingSupply, stakingPool.bonded_tokens || '0')
+      circulatingSupply = minus(circulatingSupply, stakingPool.not_bonded_tokens || '0')
     }
 
     // Remove Luna in bank wallets


### PR DESCRIPTION
Needs to be decided if only the bonded or also the not bonded part of the staking pool should be excluded.